### PR TITLE
split format.js into a few files

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
+const bencode = require('bencode')
+
+const _extractCache = new Map()
+
+function extract(nativeMsg) {
+  if (_extractCache.has(nativeMsg)) {
+    return _extractCache.get(nativeMsg)
+  }
+  const [payload, signatureBFE] = bencode.decode(nativeMsg)
+  const [authorBFE, sequence, previousBFE, timestamp, contentSection] = payload
+  const extracted = {
+    payload,
+    signatureBFE,
+    authorBFE,
+    sequence,
+    previousBFE,
+    timestamp,
+    contentSection,
+  }
+  _extractCache.set(nativeMsg, extracted)
+  return extracted
+}
+
+module.exports = extract

--- a/format.js
+++ b/format.js
@@ -6,381 +6,145 @@ const bencode = require('bencode')
 const BFE = require('ssb-bfe')
 const ssbKeys = require('ssb-keys')
 const SSBURI = require('ssb-uri2')
+const extract = require('./extract')
+const getMsgId = require('./get-msg-id')
+const getSequence = require('./get-sequence')
+const { validate } = require('./validation')
 
 const CONTENT_SIG_PREFIX = Buffer.from('bendybutt', 'utf8')
 
-const feedFormat = {
-  name: 'bendybutt-v1',
-  encodings: ['js'],
+const name = 'bendybutt-v1'
 
-  getFeedId(nativeMsg) {
-    return BFE.decode(bencode.decode(nativeMsg, 2, 39))
-  },
+const encodings = ['js']
 
-  _msgIdCache: new Map(),
-  _extractCache: new Map(),
+function getFeedId(nativeMsg) {
+  return BFE.decode(bencode.decode(nativeMsg, 2, 39))
+}
 
-  getMsgId(nativeMsg) {
-    if (feedFormat._msgIdCache.has(nativeMsg)) {
-      return feedFormat._msgIdCache.get(nativeMsg)
-    }
-    let data = ssbKeys.hash(nativeMsg)
-    if (data.endsWith('.sha256')) data = data.slice(0, -'.sha256'.length)
-    const msgId = SSBURI.compose({
-      type: 'message',
-      format: 'bendybutt-v1',
-      data,
-    })
-    feedFormat._msgIdCache.set(nativeMsg, msgId)
-    return msgId
-  },
+function isNativeMsg(x) {
+  if (!Buffer.isBuffer(x)) return false
+  if (x.length === 0) return false
+  try {
+    const { authorBFE } = extract(x)
+    return BFE.isEncodedFeedBendybuttV1(authorBFE)
+  } catch (err) {
+    return false
+  }
+}
 
-  getSequence(nativeMsg) {
-    const { sequence } = feedFormat._extract(nativeMsg)
-    return sequence
-  },
+function isAuthor(author) {
+  return typeof author === 'string' && SSBURI.isBendyButtV1FeedSSBURI(author)
+}
 
-  isNativeMsg(x) {
-    if (!Buffer.isBuffer(x)) return false
-    if (x.length === 0) return false
-    try {
-      const { authorBFE } = feedFormat._extract(x)
-      return BFE.isEncodedFeedBendybuttV1(authorBFE)
-    } catch (err) {
-      return false
-    }
-  },
+function toPlaintextBuffer(opts) {
+  const { content, contentKeys, keys, hmacKey } = opts
+  const contentBFE = BFE.encode(content)
+  const contentSignature = ssbKeys.sign(
+    contentKeys || keys,
+    hmacKey,
+    Buffer.concat([CONTENT_SIG_PREFIX, bencode.encode(contentBFE)])
+  )
+  const contentSection = [content, contentSignature]
+  return bencode.encode(BFE.encode(contentSection))
+}
 
-  isAuthor(author) {
-    return typeof author === 'string' && SSBURI.isBendyButtV1FeedSSBURI(author)
-  },
+function newNativeMsg(opts) {
+  const author = opts.keys.id
+  const previous = opts.previous || { key: null, value: { sequence: 0 } }
+  const sequence = previous.value.sequence + 1
+  const previousId = previous.key
+  const timestamp = +opts.timestamp
+  const content = opts.content
+  const contentBFE = BFE.encode(content)
+  const contentSignature = ssbKeys.sign(
+    opts.contentKeys || opts.keys,
+    opts.hmacKey,
+    Buffer.concat([CONTENT_SIG_PREFIX, bencode.encode(contentBFE)])
+  )
+  let contentSection = [content, contentSignature]
+  const payload = [author, sequence, previousId, timestamp, contentSection]
+  const payloadBen = bencode.encode(BFE.encode(payload))
+  const signature = ssbKeys.sign(opts.keys, opts.hmacKey, payloadBen)
+  return bencode.encode(BFE.encode([payload, signature]))
+}
 
-  toPlaintextBuffer(opts) {
-    const { content, contentKeys, keys, hmacKey } = opts
-    const contentBFE = BFE.encode(content)
-    const contentSignature = ssbKeys.sign(
-      contentKeys || keys,
-      hmacKey,
-      Buffer.concat([CONTENT_SIG_PREFIX, bencode.encode(contentBFE)])
-    )
-    const contentSection = [content, contentSignature]
-    return bencode.encode(BFE.encode(contentSection))
-  },
+function fromNativeMsg(nativeMsg, encoding = 'js') {
+  if (encoding === 'js') {
+    const msgBFE = bencode.decode(nativeMsg)
+    const [payload, signature] = BFE.decode(msgBFE)
+    const [author, sequence, previous, timestamp, contentSection] = payload
 
-  _extract(nativeMsg) {
-    if (feedFormat._extractCache.has(nativeMsg)) {
-      return feedFormat._extractCache.get(nativeMsg)
-    }
-    const [payload, signatureBFE] = bencode.decode(nativeMsg)
-    const [authorBFE, sequence, previousBFE, timestamp, contentSection] =
-      payload
-    const extracted = {
-      payload,
-      signatureBFE,
-      authorBFE,
+    const msgVal = {
+      author,
       sequence,
-      previousBFE,
+      previous,
       timestamp,
-      contentSection,
+      signature,
     }
-    feedFormat._extractCache.set(nativeMsg, extracted)
-    return extracted
-  },
-
-  newNativeMsg(opts) {
-    const author = opts.keys.id
-    const previous = opts.previous || { key: null, value: { sequence: 0 } }
-    const sequence = previous.value.sequence + 1
-    const previousId = previous.key
-    const timestamp = +opts.timestamp
-    const content = opts.content
-    const contentBFE = BFE.encode(content)
-    const contentSignature = ssbKeys.sign(
-      opts.contentKeys || opts.keys,
-      opts.hmacKey,
-      Buffer.concat([CONTENT_SIG_PREFIX, bencode.encode(contentBFE)])
-    )
-    let contentSection = [content, contentSignature]
-    const payload = [author, sequence, previousId, timestamp, contentSection]
-    const payloadBen = bencode.encode(BFE.encode(payload))
-    const signature = ssbKeys.sign(opts.keys, opts.hmacKey, payloadBen)
-    return bencode.encode(BFE.encode([payload, signature]))
-  },
-
-  fromNativeMsg(nativeMsg, encoding = 'js') {
-    if (encoding === 'js') {
-      const msgBFE = bencode.decode(nativeMsg)
-      const [payload, signature] = BFE.decode(msgBFE)
-      const [author, sequence, previous, timestamp, contentSection] = payload
-
-      const msgVal = {
-        author,
-        sequence,
-        previous,
-        timestamp,
-        signature,
-      }
-      if (typeof contentSection === 'string') {
-        msgVal.content = contentSection
-      } else {
-        const [content, contentSignature] = contentSection
-        msgVal.content = content
-        msgVal.contentSignature = contentSignature
-      }
-
-      return msgVal
+    if (typeof contentSection === 'string') {
+      msgVal.content = contentSection
     } else {
-      // prettier-ignore
-      throw new Error(`Feed format "${feedFormat.name}" does not support encoding "${encoding}"`)
-    }
-  },
-
-  fromDecryptedNativeMsg(plaintextBuf, nativeMsg, encoding = 'js') {
-    if (encoding === 'js') {
-      const msgVal = feedFormat.fromNativeMsg(nativeMsg, encoding)
-      const contentSection = BFE.decode(bencode.decode(plaintextBuf))
       const [content, contentSignature] = contentSection
       msgVal.content = content
       msgVal.contentSignature = contentSignature
-      return msgVal
-    } else {
-      // prettier-ignore
-      throw new Error(`Feed format "${feedFormat.name}" does not support encoding "${encoding}"`)
-    }
-  },
-
-  toNativeMsg(msg, encoding = 'js') {
-    if (encoding === 'js') {
-      const {
-        author,
-        sequence,
-        previous,
-        timestamp,
-        signature,
-        content,
-        contentSignature,
-      } = msg
-      const contentSection =
-        typeof content === 'string' ? content : [content, contentSignature]
-      const payload = [author, sequence, previous, timestamp, contentSection]
-      const msgBFE = BFE.encode([payload, signature])
-      const nativeMsg = bencode.encode(msgBFE)
-      return nativeMsg
-    } else {
-      // prettier-ignore
-      throw new Error(`Feed format "${feedFormat.name}" does not support encoding "${encoding}"`)
-    }
-  },
-
-  validate(nativeMsg, prevNativeMsg, hmacKey, cb) {
-    const {
-      _extract,
-      _validateSize,
-      _validatePrevious,
-      _validateFirstPrevious,
-      _validateHmac,
-      _validateAuthor,
-      _validateSequence,
-      _validateTimestamp,
-      _validateContentSection,
-      _validateShape,
-      _validateSignature,
-    } = feedFormat
-
-    let err
-    if ((err = _validateShape(nativeMsg))) return cb(err)
-    if ((err = _validateHmac(hmacKey))) return cb(err)
-    if ((err = _validateSize(nativeMsg))) return cb(err)
-
-    const {
-      authorBFE,
-      sequence,
-      previousBFE,
-      timestamp,
-      payload,
-      contentSection,
-      signatureBFE,
-    } = _extract(nativeMsg)
-
-    if ((err = _validateAuthor(authorBFE))) return cb(err)
-
-    if (sequence === 1) {
-      if ((err = _validateFirstPrevious(previousBFE, prevNativeMsg)))
-        return cb(err)
-    } else {
-      if ((err = _validatePrevious(previousBFE, prevNativeMsg))) return cb(err)
-      if ((err = _validateSequence(sequence, prevNativeMsg))) return cb(err)
     }
 
-    if ((err = _validateTimestamp(timestamp))) return cb(err)
-
-    if ((err = _validateSignature(signatureBFE, authorBFE, payload, hmacKey)))
-      return cb(err)
-
-    if ((err = _validateContentSection(contentSection))) return cb(err)
-
-    cb()
-  },
-
-  _validateShape(nativeMsg) {
-    if (!Buffer.isBuffer(nativeMsg)) {
-      return new Error(`invalid message: expected a buffer`)
-    }
-    const topLayer = bencode.decode(nativeMsg)
-    if (!Array.isArray(topLayer) || topLayer.length !== 2) {
-      return new Error(`invalid message: expected a bencode list of length 2`)
-    }
-    const [payload] = topLayer
-    const layer2 = payload
-    if (!Array.isArray(layer2) || layer2.length !== 5) {
-      // prettier-ignore
-      return new Error(`invalid message: expected payload to be a bencode list of length 5`)
-    }
-  },
-
-  _validateSize(nativeMsg) {
-    if (nativeMsg.length > 8192) {
-      // prettier-ignore
-      return new Error(`invalid message size: ${nativeMsg.length} bytes, must not be greater than 8192 bytes`)
-    }
-  },
-
-  _validateAuthor(authorBFE) {
-    if (!Buffer.isBuffer) {
-      return new Error(`invalid message: expected author to be a buffer`)
-    }
-    if (!BFE.isEncodedFeedBendybuttV1(authorBFE)) {
-      // prettier-ignore
-      return new Error(`invalid message: author is ${authorBFE.toString('hex')}, must be bendybutt v1 feed`)
-    }
-  },
-
-  _validateHmac(hmacKey) {
-    if (!hmacKey) return
-    if (typeof hmacKey !== 'string' && !Buffer.isBuffer(hmacKey)) {
-      return new Error('invalid hmac key: must be a string or buffer')
-    }
-    const bytes = Buffer.isBuffer(hmacKey)
-      ? hmacKey
-      : Buffer.from(hmacKey, 'base64')
-
-    if (typeof hmacKey === 'string' && bytes.toString('base64') !== hmacKey) {
-      return new Error('invalid hmac')
-    }
-
-    if (bytes.length !== 32) {
-      return new Error('invalid hmac, it should have 32 bytes')
-    }
-  },
-
-  /**
-   * Validate a message in relation to the previous message on the feed.
-   *
-   * @param {Buffer} previousBFE - Message ID of the previous message on
-   * the feed (`null` if `sequence` is `1`) encoded in BFE.
-   * @param {Buffer | null} prevNativeMsg - Previous message value as an object
-   * (`null` if `sequence` is `1`).
-   * @returns {Object | undefined} Either an Error containing a message or an
-   * `undefined` value for successful validation.
-   */
-  _validatePrevious(previousBFE, prevNativeMsg) {
-    if (!Buffer.isBuffer(previousBFE)) {
-      return new Error(`invalid message: expected previous to be a buffer`)
-    }
-    if (!BFE.isEncodedMessageBendybuttV1(previousBFE)) {
-      // prettier-ignore
-      return new Error(`invalid message: previous is "${previousBFE.toString('hex')}", expected a valid message identifier`)
-    }
-    if (!prevNativeMsg) {
-      // prettier-ignore
-      return new Error('invalid previousMsg: value must not be undefined if sequence > 1')
-    }
-    const prevMsgId = feedFormat.getMsgId(prevNativeMsg)
-    if (!previousBFE.equals(BFE.encode(prevMsgId))) {
-      // prettier-ignore
-      return new Error(`invalid message: previousBFE is "${previousBFE.toString('hex')}" but previous message author is "${prevMsgId}", expected values to be identical`)
-    }
-  },
-
-  _validateSequence(sequence, prevNativeMsg) {
-    if (!prevNativeMsg) {
-      // prettier-ignore
-      return new Error(`invalid message: sequence is ${sequence}, expected 1 because there is no previous message`)
-    }
-    const prevSequence = feedFormat.getSequence(prevNativeMsg)
-    if (sequence !== prevSequence + 1) {
-      // prettier-ignore
-      return new Error(`invalid message: sequence is ${sequence} but prevMsg sequence is ${prevSequence}, expected sequence to be prevMsg.sequence + 1`)
-    }
-  },
-
-  _validateTimestamp(timestamp) {
-    if (
-      typeof timestamp !== 'number' ||
-      isNaN(timestamp) ||
-      !isFinite(timestamp) ||
-      timestamp < 0
-    ) {
-      // prettier-ignore
-      return new Error(`invalid message: timestamp is ${timestamp}, expected a non-negative number`)
-    }
-  },
-
-  _validateFirstPrevious(previousBFE, prevNativeMsg) {
-    if (!Buffer.isBuffer(previousBFE)) {
-      return new Error(`invalid message: expected previous to be a buffer`)
-    }
-    if (!BFE.isEncodedGenericNil(previousBFE)) {
-      // prettier-ignore
-      return new Error(`invalid message: previous is "${previousBFE.toString('hex')}", expected a value of null because sequence is 1`)
-    }
-    if (prevNativeMsg) {
-      // prettier-ignore
-      return new Error('invalid message: sequence cannot be 1 if there exists a previous message')
-    }
-  },
-
-  _validateContentSection(contentSection) {
-    if (!contentSection) {
-      return new Error('invalid message: contentSection is missing')
-    }
-    if (!Array.isArray(contentSection) || contentSection.length !== 2) {
-      // prettier-ignore
-      return new Error('invalid message: contentSection should be an array with two items')
-    }
-    const [content, contentSignature] = contentSection
-    if (!content || typeof content !== 'object') {
-      // prettier-ignore
-      return new Error('invalid message: content should be an object')
-    }
-    if (!Buffer.isBuffer(contentSignature)) {
-      return new Error('invalid message: contentSignature should be a buffer')
-    }
-    if (!BFE.isEncodedSignatureMsgEd25519(contentSignature)) {
-      // prettier-ignore
-      return new Error('invalid message: contentSignature expected to be a valid BFE signature buffer')
-    }
-  },
-
-  _validateSignature(signatureBFE, authorBFE, payload, hmacKey) {
-    if (!Buffer.isBuffer(signatureBFE)) {
-      return new Error(`invalid message: expected signature to be a buffer`)
-    }
-    if (!BFE.isEncodedSignatureMsgEd25519(signatureBFE)) {
-      // prettier-ignore
-      return new Error(`invalid message: signature, expected a valid BFE signature buffer`)
-    }
-    const signature = signatureBFE.slice(2)
-    const public = authorBFE.slice(2).toString('base64') + '.ed25519'
-    const keys = { public, curve: 'ed25519' }
-    const payloadBen = bencode.encode(payload)
-    if (
-      !ssbKeys.verify(keys, signature.toString('base64'), hmacKey, payloadBen)
-    ) {
-      // prettier-ignore
-      return new Error('invalid message: signature by must correctly sign the payload')
-    }
-  },
+    return msgVal
+  } else {
+    // prettier-ignore
+    throw new Error(`Feed format "${name}" does not support encoding "${encoding}"`)
+  }
 }
 
-module.exports = feedFormat
+function fromDecryptedNativeMsg(plaintextBuf, nativeMsg, encoding = 'js') {
+  if (encoding === 'js') {
+    const msgVal = fromNativeMsg(nativeMsg, encoding)
+    const contentSection = BFE.decode(bencode.decode(plaintextBuf))
+    const [content, contentSignature] = contentSection
+    msgVal.content = content
+    msgVal.contentSignature = contentSignature
+    return msgVal
+  } else {
+    // prettier-ignore
+    throw new Error(`Feed format "${name}" does not support encoding "${encoding}"`)
+  }
+}
+
+function toNativeMsg(msg, encoding = 'js') {
+  if (encoding === 'js') {
+    const {
+      author,
+      sequence,
+      previous,
+      timestamp,
+      signature,
+      content,
+      contentSignature,
+    } = msg
+    const contentSection =
+      typeof content === 'string' ? content : [content, contentSignature]
+    const payload = [author, sequence, previous, timestamp, contentSection]
+    const msgBFE = BFE.encode([payload, signature])
+    const nativeMsg = bencode.encode(msgBFE)
+    return nativeMsg
+  } else {
+    // prettier-ignore
+    throw new Error(`Feed format "${name}" does not support encoding "${encoding}"`)
+  }
+}
+
+module.exports = {
+  name,
+  encodings,
+  getFeedId,
+  getMsgId,
+  getSequence,
+  isNativeMsg,
+  isAuthor,
+  toPlaintextBuffer,
+  newNativeMsg,
+  toNativeMsg,
+  fromNativeMsg,
+  fromDecryptedNativeMsg,
+  validate,
+}

--- a/get-msg-id.js
+++ b/get-msg-id.js
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
+const ssbKeys = require('ssb-keys')
+const SSBURI = require('ssb-uri2')
+
+const _msgIdCache = new Map()
+
+function getMsgId(nativeMsg) {
+  if (_msgIdCache.has(nativeMsg)) {
+    return _msgIdCache.get(nativeMsg)
+  }
+  let data = ssbKeys.hash(nativeMsg)
+  if (data.endsWith('.sha256')) data = data.slice(0, -'.sha256'.length)
+  const msgId = SSBURI.compose({
+    type: 'message',
+    format: 'bendybutt-v1',
+    data,
+  })
+  _msgIdCache.set(nativeMsg, msgId)
+  return msgId
+}
+
+module.exports = getMsgId

--- a/get-sequence.js
+++ b/get-sequence.js
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
+const extract = require('./extract')
+
+function getSequence(nativeMsg) {
+  const { sequence } = extract(nativeMsg)
+  return sequence
+}
+
+module.exports = getSequence

--- a/validation.js
+++ b/validation.js
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
+const BFE = require('ssb-bfe')
+const ssbKeys = require('ssb-keys')
+const bencode = require('bencode')
+const extract = require('./extract')
+const getMsgId = require('./get-msg-id')
+const getSequence = require('./get-sequence')
+
+function _validateShape(nativeMsg) {
+  if (!Buffer.isBuffer(nativeMsg)) {
+    return new Error(`invalid message: expected a buffer`)
+  }
+  const topLayer = bencode.decode(nativeMsg)
+  if (!Array.isArray(topLayer) || topLayer.length !== 2) {
+    return new Error(`invalid message: expected a bencode list of length 2`)
+  }
+  const [payload] = topLayer
+  const layer2 = payload
+  if (!Array.isArray(layer2) || layer2.length !== 5) {
+    // prettier-ignore
+    return new Error(`invalid message: expected payload to be a bencode list of length 5`)
+  }
+}
+
+function _validateSize(nativeMsg) {
+  if (nativeMsg.length > 8192) {
+    // prettier-ignore
+    return new Error(`invalid message size: ${nativeMsg.length} bytes, must not be greater than 8192 bytes`)
+  }
+}
+
+function _validateAuthor(authorBFE) {
+  if (!Buffer.isBuffer) {
+    return new Error(`invalid message: expected author to be a buffer`)
+  }
+  if (!BFE.isEncodedFeedBendybuttV1(authorBFE)) {
+    // prettier-ignore
+    return new Error(`invalid message: author is ${authorBFE.toString('hex')}, must be bendybutt v1 feed`)
+  }
+}
+
+function _validateHmac(hmacKey) {
+  if (!hmacKey) return
+  if (typeof hmacKey !== 'string' && !Buffer.isBuffer(hmacKey)) {
+    return new Error('invalid hmac key: must be a string or buffer')
+  }
+  const bytes = Buffer.isBuffer(hmacKey)
+    ? hmacKey
+    : Buffer.from(hmacKey, 'base64')
+
+  if (typeof hmacKey === 'string' && bytes.toString('base64') !== hmacKey) {
+    return new Error('invalid hmac')
+  }
+
+  if (bytes.length !== 32) {
+    return new Error('invalid hmac, it should have 32 bytes')
+  }
+}
+
+/**
+ * Validate a message in relation to the previous message on the feed.
+ *
+ * @param {Buffer} previousBFE - Message ID of the previous message on
+ * the feed (`null` if `sequence` is `1`) encoded in BFE.
+ * @param {Buffer | null} prevNativeMsg - Previous message value as an object
+ * (`null` if `sequence` is `1`).
+ * @returns {Object | undefined} Either an Error containing a message or an
+ * `undefined` value for successful validation.
+ */
+function _validatePrevious(previousBFE, prevNativeMsg) {
+  if (!Buffer.isBuffer(previousBFE)) {
+    return new Error(`invalid message: expected previous to be a buffer`)
+  }
+  if (!BFE.isEncodedMessageBendybuttV1(previousBFE)) {
+    // prettier-ignore
+    return new Error(`invalid message: previous is "${previousBFE.toString('hex')}", expected a valid message identifier`)
+  }
+  if (!prevNativeMsg) {
+    // prettier-ignore
+    return new Error('invalid previousMsg: value must not be undefined if sequence > 1')
+  }
+  const prevMsgId = getMsgId(prevNativeMsg)
+  if (!previousBFE.equals(BFE.encode(prevMsgId))) {
+    // prettier-ignore
+    return new Error(`invalid message: previousBFE is "${previousBFE.toString('hex')}" but previous message author is "${prevMsgId}", expected values to be identical`)
+  }
+}
+
+function _validateSequence(sequence, prevNativeMsg) {
+  if (!prevNativeMsg) {
+    // prettier-ignore
+    return new Error(`invalid message: sequence is ${sequence}, expected 1 because there is no previous message`)
+  }
+  const prevSequence = getSequence(prevNativeMsg)
+  if (sequence !== prevSequence + 1) {
+    // prettier-ignore
+    return new Error(`invalid message: sequence is ${sequence} but prevMsg sequence is ${prevSequence}, expected sequence to be prevMsg.sequence + 1`)
+  }
+}
+
+function _validateTimestamp(timestamp) {
+  if (
+    typeof timestamp !== 'number' ||
+    isNaN(timestamp) ||
+    !isFinite(timestamp) ||
+    timestamp < 0
+  ) {
+    // prettier-ignore
+    return new Error(`invalid message: timestamp is ${timestamp}, expected a non-negative number`)
+  }
+}
+
+function _validateFirstPrevious(previousBFE, prevNativeMsg) {
+  if (!Buffer.isBuffer(previousBFE)) {
+    return new Error(`invalid message: expected previous to be a buffer`)
+  }
+  if (!BFE.isEncodedGenericNil(previousBFE)) {
+    // prettier-ignore
+    return new Error(`invalid message: previous is "${previousBFE.toString('hex')}", expected a value of null because sequence is 1`)
+  }
+  if (prevNativeMsg) {
+    // prettier-ignore
+    return new Error('invalid message: sequence cannot be 1 if there exists a previous message')
+  }
+}
+
+function _validateContentSection(contentSection) {
+  if (!contentSection) {
+    return new Error('invalid message: contentSection is missing')
+  }
+  if (!Array.isArray(contentSection) || contentSection.length !== 2) {
+    // prettier-ignore
+    return new Error('invalid message: contentSection should be an array with two items')
+  }
+  const [content, contentSignature] = contentSection
+  if (!content || typeof content !== 'object') {
+    // prettier-ignore
+    return new Error('invalid message: content should be an object')
+  }
+  if (!Buffer.isBuffer(contentSignature)) {
+    return new Error('invalid message: contentSignature should be a buffer')
+  }
+  if (!BFE.isEncodedSignatureMsgEd25519(contentSignature)) {
+    // prettier-ignore
+    return new Error('invalid message: contentSignature expected to be a valid BFE signature buffer')
+  }
+}
+
+function _validateSignature(signatureBFE, authorBFE, payload, hmacKey) {
+  if (!Buffer.isBuffer(signatureBFE)) {
+    return new Error(`invalid message: expected signature to be a buffer`)
+  }
+  if (!BFE.isEncodedSignatureMsgEd25519(signatureBFE)) {
+    // prettier-ignore
+    return new Error(`invalid message: signature, expected a valid BFE signature buffer`)
+  }
+  const signature = signatureBFE.subarray(2)
+  const public = authorBFE.subarray(2).toString('base64') + '.ed25519'
+  const keys = { public, curve: 'ed25519' }
+  const payloadBen = bencode.encode(payload)
+  if (
+    !ssbKeys.verify(keys, signature.toString('base64'), hmacKey, payloadBen)
+  ) {
+    // prettier-ignore
+    return new Error('invalid message: signature by must correctly sign the payload')
+  }
+}
+
+function validate(nativeMsg, prevNativeMsg, hmacKey, cb) {
+  let err
+  if ((err = _validateShape(nativeMsg))) return cb(err)
+  if ((err = _validateHmac(hmacKey))) return cb(err)
+  if ((err = _validateSize(nativeMsg))) return cb(err)
+
+  const {
+    authorBFE,
+    sequence,
+    previousBFE,
+    timestamp,
+    payload,
+    contentSection,
+    signatureBFE,
+  } = extract(nativeMsg)
+
+  if ((err = _validateAuthor(authorBFE))) return cb(err)
+
+  if (sequence === 1) {
+    if ((err = _validateFirstPrevious(previousBFE, prevNativeMsg)))
+      return cb(err)
+  } else {
+    if ((err = _validatePrevious(previousBFE, prevNativeMsg))) return cb(err)
+    if ((err = _validateSequence(sequence, prevNativeMsg))) return cb(err)
+  }
+
+  if ((err = _validateTimestamp(timestamp))) return cb(err)
+
+  if ((err = _validateSignature(signatureBFE, authorBFE, payload, hmacKey)))
+    return cb(err)
+
+  if ((err = _validateContentSection(contentSection))) return cb(err)
+
+  cb()
+}
+
+module.exports = { validate }


### PR DESCRIPTION
Just a moves-files-around refactor, no hurry at all to merge.

I noticed that `feedFormat._validateAuthor` was a pretty annoying convention, so I just removed the `feedFormat` object and then all the functions just became top-level in the file where they are.

Then, I moved validation functions to `validation.js`. Because validation uses extract and getMsgId and getSequence, this meant I also had to create `extract.js`, `get-msg-id.js` and `get-sequence.js`.

Nothing else changed.